### PR TITLE
Update for renamed repo

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - run: swift run BuildTool lint
 
-  # TODO: Restore in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/2 once we've seen what form the LiveObjects spec takes
+  # TODO: Restore in https://github.com/ably/ably-liveobjects-swift-plugin/issues/2 once we've seen what form the LiveObjects spec takes
   #
   #  spec-coverage:
   #    runs-on: macos-15
@@ -254,7 +254,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-cocoa-liveobjects-plugin
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-liveobjects-swift-plugin
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       # Upload the generated documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Example:
 
 For the initial stage of development of this plugin, where we need to also iterate heavily on ably-cocoa, I've added ably-cocoa as a Git submodule, which can be found in [`ably-cocoa`](./ably-cocoa). This allows you to edit ably-cocoa from within this repo's Xcode workspace.
 
-Nearer launch, we'll remove this submodule in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/7.
+Nearer launch, we'll remove this submodule in https://github.com/ably/ably-liveobjects-swift-plugin/issues/7.
 
 ## Release process
 
@@ -137,7 +137,7 @@ For each release, the following needs to be done:
 - Update the following (we have https://github.com/ably/ably-chat-swift/issues/277 for adding a script to do this):
   - the `version` constant in [`Sources/AblyLiveObjects/Version.swift`](Sources/AblyLiveObjects/Version.swift)
   - the `from: "…"` in the SPM installation instructions in [`README.md`](README.md)
-- Go to [Github releases](https://github.com/ably/ably-cocoa-liveobjects-plugin/releases) and press the `Draft a new release` button. Choose your new branch as a target
+- Go to [Github releases](https://github.com/ably/ably-liveobjects-swift-plugin/releases) and press the `Draft a new release` button. Choose your new branch as a target
 - Press the `Choose a tag` dropdown and start typing a new tag, Github will suggest the `Create new tag x.x.x on publish` option. After you select it Github will unveil the `Generate release notes` button
 - From the newly generated changes remove everything that don't make much sense to the library user
 - Copy the final list of changes to the top of the `CHANGELOG.md` file. Modify as necessary to fit the existing format of this file

--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -66,7 +66,7 @@ internal final class DefaultCoreSDK: CoreSDK {
             return
         }
 
-        // TODO: Implement the full spec of RTO15 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/47)
+        // TODO: Implement the full spec of RTO15 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/47)
         try await DefaultInternalPlugin.sendObject(
             objectMessages: objectMessages,
             channel: channel,

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// This provides the implementation behind ``PublicDefaultLiveCounter``, via internal versions of the ``LiveCounter`` API.
 internal final class InternalDefaultLiveCounter: Sendable {
-    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3.
+    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-liveobjects-swift-plugin/issues/3.
     private let mutex = NSLock()
 
     private nonisolated(unsafe) var mutableState: MutableState

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -9,7 +9,7 @@ internal protocol LiveMapObjectPoolDelegate: AnyObject, Sendable {
 
 /// This provides the implementation behind ``PublicDefaultLiveMap``, via internal versions of the ``LiveMap`` API.
 internal final class InternalDefaultLiveMap: Sendable {
-    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3.
+    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-liveobjects-swift-plugin/issues/3.
     private let mutex = NSLock()
 
     private nonisolated(unsafe) var mutableState: MutableState
@@ -905,7 +905,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                 return .string(string)
             }
 
-            // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+            // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
             if let json = entry.data?.json {
                 switch json {
                 case let .array(array):

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -3,7 +3,7 @@ import Ably
 
 /// This provides the implementation behind ``PublicDefaultRealtimeObjects``, via internal versions of the ``RealtimeObjects`` API.
 internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPoolDelegate {
-    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3.
+    // Used for synchronizing access to all of this instance's mutable state. This is a temporary solution just to allow us to implement `Sendable`, and we'll revisit it in https://github.com/ably/ably-liveobjects-swift-plugin/issues/3.
     private let mutex = NSLock()
 
     private nonisolated(unsafe) var mutableState: MutableState!
@@ -168,7 +168,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
             }
 
             // RTO11f
-            // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/50)
+            // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
             let timestamp = clock.now
             let creationOperation = ObjectCreationHelpers.creationOperationForLiveMap(
                 entries: entries,
@@ -213,7 +213,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
 
             // RTO12f
 
-            // TODO: This is a stopgap; change to use server time per RTO12f5 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/50)
+            // TODO: This is a stopgap; change to use server time per RTO12f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
             let timestamp = clock.now
             let creationOperation = ObjectCreationHelpers.creationOperationForLiveCounter(
                 count: count,

--- a/Sources/AblyLiveObjects/Internal/InternalLiveMapValue.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalLiveMapValue.swift
@@ -32,13 +32,13 @@ internal enum InternalLiveMapValue: Sendable, Equatable {
             self = .jsonObject(value)
         case let .liveMap(publicLiveMap):
             guard let publicDefaultLiveMap = publicLiveMap as? PublicDefaultLiveMap else {
-                // TODO: Try and remove this runtime check and know this type statically, see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/37
+                // TODO: Try and remove this runtime check and know this type statically, see https://github.com/ably/ably-liveobjects-swift-plugin/issues/37
                 preconditionFailure("Expected PublicDefaultLiveMap, got \(publicLiveMap)")
             }
             self = .liveMap(publicDefaultLiveMap.proxied)
         case let .liveCounter(publicLiveCounter):
             guard let publicDefaultLiveCounter = publicLiveCounter as? PublicDefaultLiveCounter else {
-                // TODO: Try and remove this runtime check and know this type statically, see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/37
+                // TODO: Try and remove this runtime check and know this type statically, see https://github.com/ably/ably-liveobjects-swift-plugin/issues/37
                 preconditionFailure("Expected PublicDefaultLiveCounter, got \(publicLiveCounter)")
             }
             self = .liveCounter(publicDefaultLiveCounter.proxied)

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -326,7 +326,7 @@ internal struct ObjectsPool {
             case let .counter(counter):
                 return counter
             case .map:
-                // TODO: Add the ability to statically reason about the type of pool entries in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/36
+                // TODO: Add the ability to statically reason about the type of pool entries in https://github.com/ably/ably-liveobjects-swift-plugin/issues/36
                 preconditionFailure("Expected counter object with ID \(creationOperation.objectID) but found map object")
             }
         }
@@ -370,7 +370,7 @@ internal struct ObjectsPool {
             case let .map(map):
                 return map
             case .counter:
-                // TODO: Add the ability to statically reason about the type of pool entries in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/36
+                // TODO: Add the ability to statically reason about the type of pool entries in https://github.com/ably/ably-liveobjects-swift-plugin/issues/36
                 preconditionFailure("Expected map object with ID \(creationOperation.objectID) but found counter object")
             }
         }

--- a/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -60,7 +60,7 @@ internal struct ObjectData: Equatable {
     internal var bytes: Data? // OD2d
     internal var number: NSNumber? // OD2e
     internal var string: String? // OD2f
-    internal var json: JSONObjectOrArray? // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+    internal var json: JSONObjectOrArray? // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
 }
 
 internal struct ObjectsMapOp: Equatable {
@@ -289,7 +289,7 @@ internal extension ObjectData {
             }
         }
 
-        // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+        // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
         if let wireJson = wireObjectData.json {
             let jsonValue = try JSONObjectOrArray(jsonString: wireJson)
             json = jsonValue
@@ -340,7 +340,7 @@ internal extension ObjectData {
             // OD4c4: A string payload is encoded as a MessagePack string type, and the result is set on the ObjectData.string attribute
             // OD4d4: A string payload is represented as a JSON string and set on the ObjectData.string attribute
             string: string,
-            // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+            // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
             json: json?.toJSONString,
         )
     }

--- a/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
@@ -476,7 +476,7 @@ internal struct WireObjectData {
     internal var bytes: StringOrData? // OD2d
     internal var number: NSNumber? // OD2e
     internal var string: String? // OD2f
-    internal var json: String? // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+    internal var json: String? // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
 }
 
 extension WireObjectData: WireObjectCodable {

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
@@ -93,7 +93,7 @@ struct InternalDefaultLiveMapTests {
             #expect(result?.stringValue == "test")
         }
 
-        // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+        // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
         // Tests when `json` is a JSON array
         @Test
         func returnsJSONArrayValue() throws {
@@ -105,7 +105,7 @@ struct InternalDefaultLiveMapTests {
             #expect(result?.jsonArrayValue == ["foo"])
         }
 
-        // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+        // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
         // Tests when `json` is a JSON object
         @Test
         func returnsJSONObjectValue() throws {
@@ -412,8 +412,8 @@ struct InternalDefaultLiveMapTests {
                     "bytes": TestFactories.internalMapEntry(data: ObjectData(bytes: Data([0x01, 0x02, 0x03]))), // RTLM5d2c
                     "number": TestFactories.internalMapEntry(data: ObjectData(number: NSNumber(value: 42))), // RTLM5d2d
                     "string": TestFactories.internalMapEntry(data: ObjectData(string: "hello")), // RTLM5d2e
-                    "jsonArray": TestFactories.internalMapEntry(data: ObjectData(json: .array(["foo"]))), // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
-                    "jsonObject": TestFactories.internalMapEntry(data: ObjectData(json: .object(["foo": "bar"]))), // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                    "jsonArray": TestFactories.internalMapEntry(data: ObjectData(json: .array(["foo"]))), // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
+                    "jsonObject": TestFactories.internalMapEntry(data: ObjectData(json: .object(["foo": "bar"]))), // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                     "mapRef": TestFactories.internalMapEntry(data: ObjectData(objectId: "map:ref@123")), // RTLM5d2f2
                     "counterRef": TestFactories.internalMapEntry(data: ObjectData(objectId: "counter:ref@456")), // RTLM5d2f2
                 ],

--- a/Tests/AblyLiveObjectsTests/InternalDefaultRealtimeObjectsTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultRealtimeObjectsTests.swift
@@ -1091,7 +1091,7 @@ struct InternalDefaultRealtimeObjectsTests {
             #expect(publishedMessage.operation?.action == .known(.mapCreate))
             let objectID = try #require(publishedMessage.operation?.objectId)
             #expect(objectID.hasPrefix("map:"))
-            // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/50)
+            // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
             #expect(objectID.contains("1754042434000")) // check contains the mock clock's timestamp in milliseconds
             #expect(publishedMessage.operation?.map?.entries == [
                 "stringKey": .init(data: .init(string: "stringValue")),
@@ -1216,7 +1216,7 @@ struct InternalDefaultRealtimeObjectsTests {
                 #expect(publishedMessage.operation?.action == .known(.counterCreate))
                 let objectID = try #require(publishedMessage.operation?.objectId)
                 #expect(objectID.hasPrefix("counter:"))
-                // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/50)
+                // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
                 #expect(objectID.contains("1754042434000")) // check contains the mock clock's timestamp in milliseconds
                 #expect(publishedMessage.operation?.counter?.count == 10.5)
 

--- a/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
+++ b/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
@@ -237,7 +237,7 @@ struct LiveObjectMutableStateTests {
 
             // @specOneOf(2/3) RTLO4b5b - Check we can unsubscribe using the `response` that's passed to the listener, and that when two updates are emitted back-to-back, the unsubscribe in the first listener causes us to not recieve the second update
             @available(iOS 17.0.0, tvOS 17.0.0, *)
-            @Test(.disabled("This doesn't currently work and I don't think it's a priority, nor do I want to dwell on it right now or rush trying to fix it; see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/28"))
+            @Test(.disabled("This doesn't currently work and I don't think it's a priority, nor do I want to dwell on it right now or rush trying to fix it; see https://github.com/ably/ably-liveobjects-swift-plugin/issues/28"))
             func unsubscribeInsideCallback_backToBackUpdates() async throws {
                 // Given
                 let store = MutableStateStore<String>(stored: .init(objectID: "foo"))

--- a/Tests/AblyLiveObjectsTests/ObjectLifetimesTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectLifetimesTests.swift
@@ -68,7 +68,7 @@ struct ObjectLifetimesTests {
             #expect(createdObjects.weakInternalChannel != nil)
             #expect(createdObjects.weakInternalRealtimeObjects != nil)
 
-            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-liveobjects-swift-plugin/issues/30)
 
             // Note that after this return we no longer have a reference to createdObjects and thus no longer have a strong reference to our public RealtimeObjects instance
             return .init(
@@ -185,7 +185,7 @@ struct ObjectLifetimesTests {
             #expect(createdObjects.weakInternalRealtimeObjects != nil)
             #expect(createdObjects.weakInternalLiveObject != nil)
 
-            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-liveobjects-swift-plugin/issues/30)
 
             // Note that after this return we no longer have a reference to createdObjects and thus no longer have a strong reference to our public LiveObject instance
             return .init(
@@ -232,6 +232,6 @@ struct ObjectLifetimesTests {
 
         #expect(objects as AnyObject === objectsAgain as AnyObject)
         #expect(root === rootAgain)
-        // TODO: when we have an easy way of populating the ObjectsPool (i.e. once we have a write API) then also test with a non-root LiveMap and a counter (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+        // TODO: when we have an easy way of populating the ObjectsPool (i.e. once we have a write API) then also test with a non-root LiveMap and a counter (https://github.com/ably/ably-liveobjects-swift-plugin/issues/30)
     }
 }

--- a/Tests/AblyLiveObjectsTests/ObjectMessageTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectMessageTests.swift
@@ -76,7 +76,7 @@ struct ObjectMessageTests {
                     #expect(wireData.json == nil)
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 @Test(arguments: [
                     // We intentionally use a single-element object so that we get a stable encoding to JSON
                     (jsonObjectOrArray: ["key": "value"] as JSONObjectOrArray, expectedJSONString: #"{"key":"value"}"#),
@@ -159,7 +159,7 @@ struct ObjectMessageTests {
                     #expect(wireData.json == nil)
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 @Test(arguments: [
                     // We intentionally use a single-element object so that we get a stable encoding to JSON
                     (jsonObjectOrArray: ["key": "value"] as JSONObjectOrArray, expectedJSONString: #"{"key":"value"}"#),
@@ -255,14 +255,14 @@ struct ObjectMessageTests {
                     #expect(objectData.json == nil)
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 @Test
                 func json() throws {
                     let jsonString = "{\"key\":\"value\",\"number\":123}"
                     let wireData = WireObjectData(json: jsonString)
                     let objectData = try ObjectData(wireObjectData: wireData, format: .messagePack)
 
-                    // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                    // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                     #expect(objectData.boolean == nil)
                     #expect(objectData.bytes == nil)
                     #expect(objectData.number == nil)
@@ -270,7 +270,7 @@ struct ObjectMessageTests {
                     #expect(objectData.json == ["key": "value", "number": 123])
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 // The spec doesn't say what to do if JSON parsing fails; I'm choosing to treat it as an error
                 @Test
                 func json_invalidJson() {
@@ -283,7 +283,7 @@ struct ObjectMessageTests {
                     }
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 // The spec doesn't say what to do if given serialized JSON that contains a non-object-or-array value; I'm choosing to treat it as an error
                 @Test(arguments: [
                     // string
@@ -380,7 +380,7 @@ struct ObjectMessageTests {
                     }
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 @Test
                 func json() throws {
                     let jsonString = "{\"key\":\"value\",\"number\":123}"
@@ -394,7 +394,7 @@ struct ObjectMessageTests {
                     #expect(objectData.json == ["key": "value", "number": 123])
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 // The spec doesn't say what to do if JSON parsing fails; I'm choosing to treat it as an error
                 @Test
                 func json_invalidJson() {
@@ -407,7 +407,7 @@ struct ObjectMessageTests {
                     }
                 }
 
-                // TODO: Needs specification (see https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/46)
+                // TODO: Needs specification (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/46)
                 // The spec doesn't say what to do if given serialized JSON that contains a non-object-or-array value; I'm choosing to treat it as an error
                 @Test(arguments: [
                     // string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ably-cocoa-liveobjects-plugin-dev-tooling",
+  "name": "ably-liveobjects-swift-plugin-dev-tooling",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ably-cocoa-liveobjects-plugin-dev-tooling",
+      "name": "ably-liveobjects-swift-plugin-dev-tooling",
       "version": "0.1.0",
       "devDependencies": {
         "prettier": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ably-cocoa-liveobjects-plugin-dev-tooling",
+  "name": "ably-liveobjects-swift-plugin-dev-tooling",
   "version": "0.1.0",
-  "description": "Development tooling for the ably-cocoa-liveobjects-plugin repo",
+  "description": "Development tooling for the ably-liveobjects-swift-plugin repo",
   "devDependencies": {
     "prettier": "^3.3.3"
   },


### PR DESCRIPTION
**Note: This PR is based on top of #69; please review that one first.**

The repo has been renamed from `ably-cocoa-liveobjects-plugin` to `ably-liveobjects-swift-plugin`.