### PR TITLE
[ECO-5521] Implement the sync and `.deleted` events

### DIFF
--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -219,12 +219,24 @@ internal final class InternalDefaultLiveMap: Sendable {
     }
 
     @discardableResult
-    internal func on(event _: LiveObjectLifecycleEvent, callback _: @escaping LiveObjectLifecycleEventCallback) -> any OnLiveObjectLifecycleEventResponse {
-        notYetImplemented()
+    internal func on(event: LiveObjectLifecycleEvent, callback: @escaping LiveObjectLifecycleEventCallback) -> any OnLiveObjectLifecycleEventResponse {
+        mutex.withLock {
+            mutableState.liveObjectMutableState.on(event: event, callback: callback) { [weak self] action in
+                guard let self else {
+                    return
+                }
+
+                mutex.withLock {
+                    action(&mutableState.liveObjectMutableState)
+                }
+            }
+        }
     }
 
     internal func offAll() {
-        notYetImplemented()
+        mutex.withLock {
+            mutableState.liveObjectMutableState.offAll()
+        }
     }
 
     // MARK: - Emitting update from external sources
@@ -418,6 +430,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     objectMessageSerialTimestamp: objectMessageSerialTimestamp,
                     logger: logger,
                     clock: clock,
+                    userCallbackQueue: userCallbackQueue,
                 )
 
                 // RTLM6f1
@@ -605,6 +618,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     objectMessageSerialTimestamp: objectMessageSerialTimestamp,
                     logger: logger,
                     clock: clock,
+                    userCallbackQueue: userCallbackQueue,
                 )
 
                 // RTLM15d5a

--- a/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
@@ -18,6 +18,7 @@ internal extension InternalLiveObject {
         objectMessageSerialTimestamp: Date?,
         logger: Logger,
         clock: SimpleClock,
+        userCallbackQueue: DispatchQueue,
     ) {
         // RTLO4e2, RTLO4e3
         if let objectMessageSerialTimestamp {
@@ -32,6 +33,11 @@ internal extension InternalLiveObject {
 
         // RTLO4e4
         resetDataToZeroValued()
+
+        // Emit the deleted lifecycle event
+        // Taken from https://github.com/ably/ably-js/blob/0c5baa9273ca87aec6ca594833d59c4c4d2dddbb/src/plugins/objects/liveobject.ts#L168
+        // TODO: Bring in line with spec once it exists (https://github.com/ably/ably-liveobjects-swift-plugin/issues/77)
+        liveObjectMutableState.emitLifecycleEvent(.deleted, on: userCallbackQueue)
     }
 
     /// Applies an `OBJECT_DELETE` operation, per RTLO5.
@@ -39,12 +45,14 @@ internal extension InternalLiveObject {
         objectMessageSerialTimestamp: Date?,
         logger: Logger,
         clock: SimpleClock,
+        userCallbackQueue: DispatchQueue,
     ) {
         // RTLO5b
         tombstone(
             objectMessageSerialTimestamp: objectMessageSerialTimestamp,
             logger: logger,
             clock: clock,
+            userCallbackQueue: userCallbackQueue,
         )
     }
 }

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -83,7 +83,7 @@ internal struct LiveObjectMutableState<Update: Sendable> {
     /// Accepts an action, which, if called, should be called with an `inout` reference to the externally-held copy. The function is not required to call this action (for example, if the function holds a weak reference which is now `nil`).
     ///
     /// Note that the `LiveObjectMutableState` will store a copy of this function and thus this function should be careful not to introduce a strong reference cycle.
-    internal typealias UpdateLiveObject = @Sendable (_ action: (inout LiveObjectMutableState<Update>) -> Void) -> Void
+    internal typealias UpdateLiveObject = @Sendable (_ action: (inout Self) -> Void) -> Void
 
     private struct SubscribeResponse: AblyLiveObjects.SubscribeResponse {
         var subscriptionID: Subscription.ID

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -20,8 +20,8 @@ internal struct LiveObjectMutableState<Update: Sendable> {
     // RTLO3e
     internal var tombstonedAt: Date?
 
-    /// Internal bookkeeping for subscriptions.
-    private var subscriptionsByID: [Subscription.ID: Subscription] = [:]
+    /// Internal subscription storage.
+    private var subscriptionStorage = SubscriptionStorage<Update>()
 
     internal init(
         objectID: String,
@@ -72,47 +72,24 @@ internal struct LiveObjectMutableState<Update: Sendable> {
 
     // MARK: - Subscriptions
 
-    private struct Subscription: Identifiable {
-        var id = UUID()
-        var listener: LiveObjectUpdateCallback<Update>
-        var updateLiveObject: UpdateLiveObject
-    }
-
-    /// A function that allows a `LiveObjectMutableState` to later perform mutations to an externally-held copy of itself. This is used to allow a `SubscribeResponse` to unsubscribe.
-    ///
-    /// Accepts an action, which, if called, should be called with an `inout` reference to the externally-held copy. The function is not required to call this action (for example, if the function holds a weak reference which is now `nil`).
-    ///
-    /// Note that the `LiveObjectMutableState` will store a copy of this function and thus this function should be careful not to introduce a strong reference cycle.
     internal typealias UpdateLiveObject = @Sendable (_ action: (inout Self) -> Void) -> Void
-
-    private struct SubscribeResponse: AblyLiveObjects.SubscribeResponse {
-        var subscriptionID: Subscription.ID
-        var updateLiveObject: UpdateLiveObject
-
-        func unsubscribe() {
-            updateLiveObject { liveObject in
-                liveObject.unsubscribe(subscriptionID: subscriptionID)
-            }
-        }
-    }
 
     @discardableResult
     internal mutating func subscribe(listener: @escaping LiveObjectUpdateCallback<Update>, coreSDK: CoreSDK, updateSelfLater: @escaping UpdateLiveObject) throws(ARTErrorInfo) -> any AblyLiveObjects.SubscribeResponse {
         // RTLO4b2
         try coreSDK.validateChannelState(notIn: [.detached, .failed], operationDescription: "subscribe")
 
-        let subscription = Subscription(listener: listener, updateLiveObject: updateSelfLater)
-        subscriptionsByID[subscription.id] = subscription
-        return SubscribeResponse(subscriptionID: subscription.id, updateLiveObject: updateSelfLater)
+        let updateSubscriptionStorage: SubscriptionStorage<Update>.UpdateSubscriptionStorage = { action in
+            updateSelfLater { liveObject in
+                action(&liveObject.subscriptionStorage)
+            }
+        }
+
+        return subscriptionStorage.subscribe(listener: listener, updateSelfLater: updateSubscriptionStorage)
     }
 
     internal mutating func unsubscribeAll() {
-        subscriptionsByID.removeAll()
-    }
-
-    private mutating func unsubscribe(subscriptionID: Subscription.ID) {
-        // RTLO4d
-        subscriptionsByID.removeValue(forKey: subscriptionID)
+        subscriptionStorage.unsubscribeAll()
     }
 
     internal func emit(_ update: LiveObjectUpdate<Update>, on queue: DispatchQueue) {
@@ -122,12 +99,7 @@ internal struct LiveObjectMutableState<Update: Sendable> {
             return
         case let .update(update):
             // RTLO4b4c2
-            for subscription in subscriptionsByID.values {
-                queue.async {
-                    let response = SubscribeResponse(subscriptionID: subscription.id, updateLiveObject: subscription.updateLiveObject)
-                    subscription.listener(update, response)
-                }
-            }
+            subscriptionStorage.emit(update, on: queue)
         }
     }
 }

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -83,6 +83,7 @@ internal struct ObjectsPool {
             using state: ObjectState,
             objectMessageSerialTimestamp: Date?,
             objectsPool: inout ObjectsPool,
+            userCallbackQueue: DispatchQueue,
         ) -> DeferredUpdate {
             switch self {
             case let .map(map):
@@ -245,6 +246,7 @@ internal struct ObjectsPool {
                     using: syncObjectsPoolEntry.state,
                     objectMessageSerialTimestamp: syncObjectsPoolEntry.objectMessageSerialTimestamp,
                     objectsPool: &self,
+                    userCallbackQueue: userCallbackQueue,
                 )
                 // RTO5c1a2: Store this update to emit at end
                 updatesToExistingObjects.append(deferredUpdate)

--- a/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
+++ b/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
@@ -80,3 +80,12 @@ internal struct SubscriptionStorage<EventName: Hashable & Sendable, Update: Send
         }
     }
 }
+
+// MARK: - Convenience extension for Void updates
+
+internal extension SubscriptionStorage where Update == Void {
+    /// Convenience method for emitting events when there's no update data to pass.
+    func emit(eventName: EventName, on queue: DispatchQueue) {
+        emit((), eventName: eventName, on: queue)
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
+++ b/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Handles subscription bookkeeping, providing methods for subscribing and emitting events.
+internal struct SubscriptionStorage<Update: Sendable> {
+    /// Internal bookkeeping for subscriptions.
+    private var subscriptionsByID: [Subscription.ID: Subscription] = [:]
+
+    // MARK: - Subscriptions
+
+    private struct Subscription: Identifiable {
+        var id = UUID()
+        var listener: LiveObjectUpdateCallback<Update>
+        var updateSubscriptionStorage: UpdateSubscriptionStorage
+    }
+
+    /// A function that allows a `SubscriptionStorage` to later perform mutations to an externally-held copy of itself. This is used to allow a `SubscribeResponse` to unsubscribe.
+    ///
+    /// Accepts an action, which, if called, should be called with an `inout` reference to the externally-held copy. The function is not required to call this action (for example, if the function holds a weak reference which is now `nil`).
+    ///
+    /// Note that the `SubscriptionStorage` will store a copy of this function and thus this function should be careful not to introduce a strong reference cycle.
+    internal typealias UpdateSubscriptionStorage = @Sendable (_ action: (inout Self) -> Void) -> Void
+
+    private struct SubscribeResponse: AblyLiveObjects.SubscribeResponse {
+        var subscriptionID: Subscription.ID
+        var updateSubscriptionStorage: UpdateSubscriptionStorage
+
+        func unsubscribe() {
+            updateSubscriptionStorage { subscriptionStorage in
+                subscriptionStorage.unsubscribe(subscriptionID: subscriptionID)
+            }
+        }
+    }
+
+    @discardableResult
+    internal mutating func subscribe(listener: @escaping LiveObjectUpdateCallback<Update>, updateSelfLater: @escaping UpdateSubscriptionStorage) -> any AblyLiveObjects.SubscribeResponse {
+        let subscription = Subscription(listener: listener, updateSubscriptionStorage: updateSelfLater)
+        subscriptionsByID[subscription.id] = subscription
+        return SubscribeResponse(subscriptionID: subscription.id, updateSubscriptionStorage: updateSelfLater)
+    }
+
+    internal mutating func unsubscribeAll() {
+        subscriptionsByID.removeAll()
+    }
+
+    private mutating func unsubscribe(subscriptionID: Subscription.ID) {
+        subscriptionsByID.removeValue(forKey: subscriptionID)
+    }
+
+    internal func emit(_ update: Update, on queue: DispatchQueue) {
+        for subscription in subscriptionsByID.values {
+            queue.async {
+                let response = SubscribeResponse(subscriptionID: subscription.id, updateSubscriptionStorage: subscription.updateSubscriptionStorage)
+                subscription.listener(update, response)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements the following methods:

- `LiveObject.on(event:callback:)` — specifically, the `.deleted` event, which is emitted when a LiveObject is deleted by Realtime
- `RealtimeObjects.on(event:callback:)` — specifically, the `.syncing` and `.synced` events, which are emitted when the channel's objects pool is being synced

I was going to leave this out of the 0.1 release but given that the documentation is already written and it's been implemented in Kotlin I thought I might as well do it. Was done in a bit of a rush, largely by LLM, and there are some things to sort out later (see commit messages). It's all based on the JS implementation because there's no spec for it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added event subscriptions for objects and live object lifecycle, including support for syncing/synced and deleted events.
  - Introduced a single-call “unsubscribe all” capability for events.

- Improvements
  - Callbacks now execute on the user-specified queue, improving responsiveness and thread-safety.
  - Lifecycle and update events are delivered more reliably during state transitions (attach, sync, delete).
  - Streamlined internal subscription handling for more consistent event delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->