### PR TITLE
[ECO-5385] Document the approach for using ably-cocoa internals in tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,10 @@ Example:
 // @specNotApplicable CHA-EX3a - Our API does not have a concept of "partial options" unlike the JS API which this spec item considers.
 ```
 
+#### Using ably-cocoa internals in tests
+
+Some of our integration tests require access to ably-cocoa internals that are not exposed via `_AblyPluginSupportPrivate`, for example to inject protocol messages. Since, unlike the plugin implementation, the test suite does not require access to a stable private API (as it will never be compiled by end users and we're in control of which version of ably-cocoa gets used for testing the plugin), we just directly import ably-cocoa's internal APIs in the test suite using `import Ably.Private`.
+
 ## Developing ably-cocoa alongside this plugin
 
 The quickest way to edit ably-cocoa is to use `swift package edit ably-cocoa --path ably-cocoa`, which will give you a Git checkout of ably-cocoa at `ably-cocoa`. To edit ably-cocoa using Xcode, you will then need to open `ably-cocoa/Package.swift` _separately_ (making sure to close any other LiveObjects Xcode windows, else Xcode will not let you edit it).


### PR DESCRIPTION
Resolves #10. This is the simplest of the potential options outlined in that issue but it seems sufficient for now. The only downside so far has been the duplication of `TestProxyTransport` but I think we can live with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for contributors on leveraging SDK internals in integration tests, including when and how to use private APIs safely.
  * Expanded instructions for developing the SDK alongside this plugin, with clear steps for Xcode vs Swift Package Manager setups and editing workflows.
  * Improves contributor onboarding and troubleshooting.
  * No changes to application functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->