### PR TITLE
[ECO-5495] Directly use `ObjectsPool` inside `LiveMap` getter methods

### DIFF
--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -2,7 +2,7 @@ internal import _AblyPluginSupportPrivate
 import Ably
 
 /// Protocol for accessing objects from the ObjectsPool. This is used by a LiveMap when it needs to return an object given an object ID.
-internal protocol LiveMapObjectPoolDelegate: AnyObject, Sendable {
+internal protocol LiveMapObjectsPoolDelegate: AnyObject, Sendable {
     /// A snapshot of the objects pool.
     var nosync_objectsPool: ObjectsPool { get }
 }
@@ -121,7 +121,7 @@ internal final class InternalDefaultLiveMap: Sendable {
     // MARK: - Internal methods that back LiveMap conformance
 
     /// Returns the value associated with a given key, following RTLM5d specification.
-    internal func get(key: String, coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> InternalLiveMapValue? {
+    internal func get(key: String, coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate) throws(ARTErrorInfo) -> InternalLiveMapValue? {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
             try mutableState.nosync_get(
                 key: key,
@@ -131,7 +131,7 @@ internal final class InternalDefaultLiveMap: Sendable {
         }
     }
 
-    internal func size(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> Int {
+    internal func size(coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate) throws(ARTErrorInfo) -> Int {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
             try mutableState.nosync_size(
                 coreSDK: coreSDK,
@@ -140,7 +140,7 @@ internal final class InternalDefaultLiveMap: Sendable {
         }
     }
 
-    internal func entries(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> [(key: String, value: InternalLiveMapValue)] {
+    internal func entries(coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate) throws(ARTErrorInfo) -> [(key: String, value: InternalLiveMapValue)] {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
             try mutableState.nosync_entries(
                 coreSDK: coreSDK,
@@ -149,12 +149,12 @@ internal final class InternalDefaultLiveMap: Sendable {
         }
     }
 
-    internal func keys(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> [String] {
+    internal func keys(coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate) throws(ARTErrorInfo) -> [String] {
         // RTLM12b: Identical to LiveMap#entries, except that it returns only the keys from the internal data map
         try entries(coreSDK: coreSDK, delegate: delegate).map(\.key)
     }
 
-    internal func values(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> [InternalLiveMapValue] {
+    internal func values(coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate) throws(ARTErrorInfo) -> [InternalLiveMapValue] {
         // RTLM13b: Identical to LiveMap#entries, except that it returns only the values from the internal data map
         try entries(coreSDK: coreSDK, delegate: delegate).map(\.value)
     }

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -3,8 +3,8 @@ import Ably
 
 /// Protocol for accessing objects from the ObjectsPool. This is used by a LiveMap when it needs to return an object given an object ID.
 internal protocol LiveMapObjectPoolDelegate: AnyObject, Sendable {
-    /// Fetches an object from the pool by its ID
-    func nosync_getObjectFromPool(id: String) -> ObjectsPool.Entry?
+    /// A snapshot of the objects pool.
+    var nosync_objectsPool: ObjectsPool { get }
 }
 
 /// This provides the implementation behind ``PublicDefaultLiveMap``, via internal versions of the ``LiveMap`` API.
@@ -916,7 +916,7 @@ internal final class InternalDefaultLiveMap: Sendable {
 
             // RTLM14c
             if let objectId = entry.data?.objectId {
-                if let poolEntry = delegate.nosync_getObjectFromPool(id: objectId), poolEntry.nosync_isTombstone {
+                if let poolEntry = delegate.nosync_objectsPool.entries[objectId], poolEntry.nosync_isTombstone {
                     return true
                 }
             }
@@ -968,7 +968,7 @@ internal final class InternalDefaultLiveMap: Sendable {
             // RTLM5d2f: If ObjectsMapEntry.data.objectId exists, get the object stored at that objectId from the internal ObjectsPool
             if let objectId = entry.data?.objectId {
                 // RTLM5d2f1: If an object with id objectId does not exist, return undefined/null
-                guard let poolEntry = delegate.nosync_getObjectFromPool(id: objectId) else {
+                guard let poolEntry = delegate.nosync_objectsPool.entries[objectId] else {
                     return nil
                 }
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -123,19 +123,29 @@ internal final class InternalDefaultLiveMap: Sendable {
     /// Returns the value associated with a given key, following RTLM5d specification.
     internal func get(key: String, coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> InternalLiveMapValue? {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
-            try mutableState.nosync_get(key: key, coreSDK: coreSDK, delegate: delegate)
+            try mutableState.nosync_get(
+                key: key,
+                coreSDK: coreSDK,
+                objectsPool: delegate.nosync_objectsPool,
+            )
         }
     }
 
     internal func size(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> Int {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
-            try mutableState.nosync_size(coreSDK: coreSDK, delegate: delegate)
+            try mutableState.nosync_size(
+                coreSDK: coreSDK,
+                objectsPool: delegate.nosync_objectsPool,
+            )
         }
     }
 
     internal func entries(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> [(key: String, value: InternalLiveMapValue)] {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
-            try mutableState.nosync_entries(coreSDK: coreSDK, delegate: delegate)
+            try mutableState.nosync_entries(
+                coreSDK: coreSDK,
+                objectsPool: delegate.nosync_objectsPool,
+            )
         }
     }
 
@@ -859,7 +869,7 @@ internal final class InternalDefaultLiveMap: Sendable {
         }
 
         /// Returns the value associated with a given key, following RTLM5d specification.
-        internal func nosync_get(key: String, coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> InternalLiveMapValue? {
+        internal func nosync_get(key: String, coreSDK: CoreSDK, objectsPool: ObjectsPool) throws(ARTErrorInfo) -> InternalLiveMapValue? {
             // RTLM5c: If the channel is in the DETACHED or FAILED state, the library should indicate an error with code 90001
             try coreSDK.nosync_validateChannelState(notIn: [.detached, .failed], operationDescription: "LiveMap.get")
 
@@ -874,20 +884,20 @@ internal final class InternalDefaultLiveMap: Sendable {
             }
 
             // RTLM5d2: If a ObjectsMapEntry exists at the key, convert it using the shared logic
-            return nosync_convertEntryToLiveMapValue(entry, delegate: delegate)
+            return nosync_convertEntryToLiveMapValue(entry, objectsPool: objectsPool)
         }
 
-        internal func nosync_size(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> Int {
+        internal func nosync_size(coreSDK: CoreSDK, objectsPool: ObjectsPool) throws(ARTErrorInfo) -> Int {
             // RTLM10c: If the channel is in the DETACHED or FAILED state, the library should throw an ErrorInfo error with statusCode 400 and code 90001
             try coreSDK.nosync_validateChannelState(notIn: [.detached, .failed], operationDescription: "LiveMap.size")
 
             // RTLM10d: Returns the number of non-tombstoned entries (per RTLM14) in the internal data map
             return data.values.count { entry in
-                !Self.nosync_isEntryTombstoned(entry, delegate: delegate)
+                !Self.nosync_isEntryTombstoned(entry, objectsPool: objectsPool)
             }
         }
 
-        internal func nosync_entries(coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate) throws(ARTErrorInfo) -> [(key: String, value: InternalLiveMapValue)] {
+        internal func nosync_entries(coreSDK: CoreSDK, objectsPool: ObjectsPool) throws(ARTErrorInfo) -> [(key: String, value: InternalLiveMapValue)] {
             // RTLM11c: If the channel is in the DETACHED or FAILED state, the library should throw an ErrorInfo error with statusCode 400 and code 90001
             try coreSDK.nosync_validateChannelState(notIn: [.detached, .failed], operationDescription: "LiveMap.entries")
 
@@ -895,9 +905,9 @@ internal final class InternalDefaultLiveMap: Sendable {
             // RTLM11d1: Pairs with tombstoned entries (per RTLM14) are not returned
             var result: [(key: String, value: InternalLiveMapValue)] = []
 
-            for (key, entry) in data where !Self.nosync_isEntryTombstoned(entry, delegate: delegate) {
+            for (key, entry) in data where !Self.nosync_isEntryTombstoned(entry, objectsPool: objectsPool) {
                 // Convert entry to LiveMapValue using the same logic as get(key:)
-                if let value = nosync_convertEntryToLiveMapValue(entry, delegate: delegate) {
+                if let value = nosync_convertEntryToLiveMapValue(entry, objectsPool: objectsPool) {
                     result.append((key: key, value: value))
                 }
             }
@@ -908,7 +918,7 @@ internal final class InternalDefaultLiveMap: Sendable {
         // MARK: - Helper Methods
 
         /// Returns whether a map entry should be considered tombstoned, per the check described in RTLM14.
-        private static func nosync_isEntryTombstoned(_ entry: InternalObjectsMapEntry, delegate: LiveMapObjectPoolDelegate) -> Bool {
+        private static func nosync_isEntryTombstoned(_ entry: InternalObjectsMapEntry, objectsPool: ObjectsPool) -> Bool {
             // RTLM14a
             if entry.tombstone {
                 return true
@@ -916,7 +926,7 @@ internal final class InternalDefaultLiveMap: Sendable {
 
             // RTLM14c
             if let objectId = entry.data?.objectId {
-                if let poolEntry = delegate.nosync_objectsPool.entries[objectId], poolEntry.nosync_isTombstone {
+                if let poolEntry = objectsPool.entries[objectId], poolEntry.nosync_isTombstone {
                     return true
                 }
             }
@@ -927,7 +937,7 @@ internal final class InternalDefaultLiveMap: Sendable {
 
         /// Converts an InternalObjectsMapEntry to LiveMapValue using the same logic as get(key:)
         /// This is used by entries to ensure consistent value conversion
-        private func nosync_convertEntryToLiveMapValue(_ entry: InternalObjectsMapEntry, delegate: LiveMapObjectPoolDelegate) -> InternalLiveMapValue? {
+        private func nosync_convertEntryToLiveMapValue(_ entry: InternalObjectsMapEntry, objectsPool: ObjectsPool) -> InternalLiveMapValue? {
             // RTLM5d2a: If ObjectsMapEntry.tombstone is true, return undefined/null
             if entry.tombstone == true {
                 return nil
@@ -968,7 +978,7 @@ internal final class InternalDefaultLiveMap: Sendable {
             // RTLM5d2f: If ObjectsMapEntry.data.objectId exists, get the object stored at that objectId from the internal ObjectsPool
             if let objectId = entry.data?.objectId {
                 // RTLM5d2f1: If an object with id objectId does not exist, return undefined/null
-                guard let poolEntry = delegate.nosync_objectsPool.entries[objectId] else {
+                guard let poolEntry = objectsPool.entries[objectId] else {
                     return nil
                 }
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -141,9 +141,9 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
 
     // MARK: - LiveMapObjectPoolDelegate
 
-    internal func nosync_getObjectFromPool(id: String) -> ObjectsPool.Entry? {
+    internal var nosync_objectsPool: ObjectsPool {
         mutableStateMutex.withoutSync { mutableState in
-            mutableState.objectsPool.entries[id]
+            mutableState.objectsPool
         }
     }
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -2,7 +2,7 @@ internal import _AblyPluginSupportPrivate
 import Ably
 
 /// This provides the implementation behind ``PublicDefaultRealtimeObjects``, via internal versions of the ``RealtimeObjects`` API.
-internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPoolDelegate {
+internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoolDelegate {
     private let mutableStateMutex: DispatchQueueMutex<MutableState>
 
     private let logger: Logger
@@ -139,7 +139,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
         garbageCollectionTask.cancel()
     }
 
-    // MARK: - LiveMapObjectPoolDelegate
+    // MARK: - LiveMapObjectsPoolDelegate
 
     internal var nosync_objectsPool: ObjectsPool {
         mutableStateMutex.withoutSync { mutableState in

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/InternalLiveMapValue+ToPublic.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/InternalLiveMapValue+ToPublic.swift
@@ -5,7 +5,7 @@ internal extension InternalLiveMapValue {
 
     struct PublicValueCreationArgs {
         internal var coreSDK: CoreSDK
-        internal var mapDelegate: LiveMapObjectPoolDelegate
+        internal var mapDelegate: LiveMapObjectsPoolDelegate
         internal var logger: Logger
 
         internal var toCounterCreationArgs: PublicObjectsStore.CounterCreationArgs {

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveMap.swift
@@ -10,10 +10,10 @@ internal final class PublicDefaultLiveMap: LiveMap {
     // MARK: - Dependencies that hold a strong reference to `proxied`
 
     private let coreSDK: CoreSDK
-    private let delegate: LiveMapObjectPoolDelegate
+    private let delegate: LiveMapObjectsPoolDelegate
     private let logger: Logger
 
-    internal init(proxied: InternalDefaultLiveMap, coreSDK: CoreSDK, delegate: LiveMapObjectPoolDelegate, logger: Logger) {
+    internal init(proxied: InternalDefaultLiveMap, coreSDK: CoreSDK, delegate: LiveMapObjectsPoolDelegate, logger: Logger) {
         self.proxied = proxied
         self.coreSDK = coreSDK
         self.delegate = delegate

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicObjectsStore.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicObjectsStore.swift
@@ -45,7 +45,7 @@ internal final class PublicObjectsStore: Sendable {
 
     internal struct MapCreationArgs {
         internal var coreSDK: CoreSDK
-        internal var delegate: LiveMapObjectPoolDelegate
+        internal var delegate: LiveMapObjectsPoolDelegate
         internal var logger: Logger
     }
 

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
@@ -15,7 +15,7 @@ struct InternalDefaultLiveMapTests {
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 
             #expect {
-                _ = try map.get(key: "test", coreSDK: MockCoreSDK(channelState: channelState, internalQueue: internalQueue), delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+                _ = try map.get(key: "test", coreSDK: MockCoreSDK(channelState: channelState, internalQueue: internalQueue), delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             } throws: { error in
                 guard let errorInfo = error as? ARTErrorInfo else {
                     return false
@@ -34,7 +34,7 @@ struct InternalDefaultLiveMapTests {
             let internalQueue = TestFactories.createInternalQueue()
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            #expect(try map.get(key: "nonexistent", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)) == nil)
+            #expect(try map.get(key: "nonexistent", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)) == nil)
         }
 
         // @spec RTLM5d2a
@@ -48,7 +48,7 @@ struct InternalDefaultLiveMapTests {
             let internalQueue = TestFactories.createInternalQueue()
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            #expect(try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)) == nil)
+            #expect(try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)) == nil)
         }
 
         // @spec RTLM5d2b
@@ -59,7 +59,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(boolean: true))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.boolValue == true)
         }
 
@@ -72,7 +72,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(bytes: bytes))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.dataValue == bytes)
         }
 
@@ -84,7 +84,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(number: NSNumber(value: 123.456)))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.numberValue == 123.456)
         }
 
@@ -96,7 +96,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(string: "test"))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.stringValue == "test")
         }
 
@@ -109,7 +109,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(json: .array(["foo"])))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.jsonArrayValue == ["foo"])
         }
 
@@ -122,7 +122,7 @@ struct InternalDefaultLiveMapTests {
             let entry = TestFactories.internalMapEntry(data: ObjectData(json: .object(["foo": "bar"])))
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
-            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectPoolDelegate(internalQueue: internalQueue))
+            let result = try map.get(key: "key", coreSDK: coreSDK, delegate: MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue))
             #expect(result?.jsonObjectValue == ["foo": "bar"])
         }
 
@@ -132,7 +132,7 @@ struct InternalDefaultLiveMapTests {
             let logger = TestLogger()
             let entry = TestFactories.internalMapEntry(data: ObjectData(objectId: "missing"))
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             #expect(try map.get(key: "key", coreSDK: coreSDK, delegate: delegate) == nil)
@@ -145,7 +145,7 @@ struct InternalDefaultLiveMapTests {
             let internalQueue = TestFactories.createInternalQueue()
             let objectId = "map1"
             let entry = TestFactories.internalMapEntry(data: ObjectData(objectId: objectId))
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let referencedMap = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             delegate.objects[objectId] = .map(referencedMap)
@@ -162,7 +162,7 @@ struct InternalDefaultLiveMapTests {
             let internalQueue = TestFactories.createInternalQueue()
             let objectId = "counter1"
             let entry = TestFactories.internalMapEntry(data: ObjectData(objectId: objectId))
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let referencedCounter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             delegate.objects[objectId] = .counter(referencedCounter)
@@ -178,7 +178,7 @@ struct InternalDefaultLiveMapTests {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
             let entry = TestFactories.internalMapEntry(data: ObjectData())
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             #expect(try map.get(key: "key", coreSDK: coreSDK, delegate: delegate) == nil)
@@ -241,7 +241,7 @@ struct InternalDefaultLiveMapTests {
         func setsDataToMapEntries() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             let (key, entry) = TestFactories.stringMapEntry(key: "key1", value: "test")
@@ -265,7 +265,7 @@ struct InternalDefaultLiveMapTests {
         func mergesInitialValueWhenCreateOpPresent() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             let state = TestFactories.objectState(
@@ -309,7 +309,7 @@ struct InternalDefaultLiveMapTests {
             let internalQueue = TestFactories.createInternalQueue()
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             let coreSDK = MockCoreSDK(channelState: channelState, internalQueue: internalQueue)
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
 
             // Define actions to test
             let actions: [(String, () throws -> Any)] = [
@@ -344,7 +344,7 @@ struct InternalDefaultLiveMapTests {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(
                 testsOnly_data: [
                     // tombstonedAt is nil, so not considered tombstoned
@@ -391,7 +391,7 @@ struct InternalDefaultLiveMapTests {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(
                 testsOnly_data: [
                     "key1": TestFactories.internalMapEntry(data: ObjectData(string: "value1")),
@@ -430,7 +430,7 @@ struct InternalDefaultLiveMapTests {
         func entriesHandlesAllValueTypes() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
 
             // Create referenced objects for testing
@@ -498,7 +498,7 @@ struct InternalDefaultLiveMapTests {
             func discardsOperationWhenCannotBeApplied() throws {
                 let logger = TestLogger()
                 let internalQueue = TestFactories.createInternalQueue()
-                let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+                let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
                 let map = InternalDefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.internalMapEntry(timeserial: "ts2", data: ObjectData(string: "existing"))],
@@ -530,17 +530,17 @@ struct InternalDefaultLiveMapTests {
             // @specOneOf(1/2) RTLM7c1
             // @specOneOf(1/2) RTLM7f
             @Test(arguments: [
-                // Case 1: ObjectData refers to a number value (shouldn't modify the ObjectPool per RTLM7c)
+                // Case 1: ObjectData refers to a number value (shouldn't modify the ObjectsPool per RTLM7c)
                 (operationData: ObjectData(number: NSNumber(value: 42)), expectedCreatedObjectID: nil),
-                // Case 2: ObjectData refers to an object value but the object ID is an empty string (shouldn't modify the ObjectPool per RTLM7c)
+                // Case 2: ObjectData refers to an object value but the object ID is an empty string (shouldn't modify the ObjectsPool per RTLM7c)
                 (operationData: ObjectData(objectId: ""), expectedCreatedObjectID: nil),
-                // Case 3: ObjectData refers to an object value (should modify the ObjectPool per RTLM7c and RTLM7c1)
+                // Case 3: ObjectData refers to an object value (should modify the ObjectsPool per RTLM7c and RTLM7c1)
                 (operationData: ObjectData(objectId: "map:referenced@123"), expectedCreatedObjectID: "map:referenced@123"),
             ] as [(operationData: ObjectData, expectedCreatedObjectID: String?)])
             func appliesOperationWhenCanBeApplied(operationData: ObjectData, expectedCreatedObjectID: String?) throws {
                 let logger = TestLogger()
                 let internalQueue = TestFactories.createInternalQueue()
-                let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+                let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
                 let map = InternalDefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstonedAt: Date(), timeserial: "ts1", data: ObjectData(string: "existing"))],
@@ -605,17 +605,17 @@ struct InternalDefaultLiveMapTests {
             // @specOneOf(2/2) RTLM7c1
             // @specOneOf(2/2) RTLM7f
             @Test(arguments: [
-                // Case 1: ObjectData refers to a number value (shouldn't modify the ObjectPool per RTLM7c)
+                // Case 1: ObjectData refers to a number value (shouldn't modify the ObjectsPool per RTLM7c)
                 (operationData: ObjectData(number: NSNumber(value: 42)), expectedCreatedObjectID: nil),
-                // Case 2: ObjectData refers to an object value but the object ID is an empty string (shouldn't modify the ObjectPool per RTLM7c)
+                // Case 2: ObjectData refers to an object value but the object ID is an empty string (shouldn't modify the ObjectsPool per RTLM7c)
                 (operationData: ObjectData(objectId: ""), expectedCreatedObjectID: nil),
-                // Case 3: ObjectData refers to an object value (should modify the ObjectPool per RTLM7c and RTLM7c1)
+                // Case 3: ObjectData refers to an object value (should modify the ObjectsPool per RTLM7c and RTLM7c1)
                 (operationData: ObjectData(objectId: "map:referenced@123"), expectedCreatedObjectID: "map:referenced@123"),
             ] as [(operationData: ObjectData, expectedCreatedObjectID: String?)])
             func createsNewEntryWhenNoExistingEntry(operationData: ObjectData, expectedCreatedObjectID: String?) throws {
                 let logger = TestLogger()
                 let internalQueue = TestFactories.createInternalQueue()
-                let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+                let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
                 let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
                 var pool = ObjectsPool(logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
@@ -666,7 +666,7 @@ struct InternalDefaultLiveMapTests {
         func doesNotReplaceExistingObjectWhenReferencedByMapSet() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 
@@ -718,7 +718,7 @@ struct InternalDefaultLiveMapTests {
             func discardsOperationWhenCannotBeApplied() throws {
                 let logger = TestLogger()
                 let internalQueue = TestFactories.createInternalQueue()
-                let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+                let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
                 let map = InternalDefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.internalMapEntry(timeserial: "ts2", data: ObjectData(string: "existing"))],
@@ -746,7 +746,7 @@ struct InternalDefaultLiveMapTests {
             func appliesOperationWhenCanBeApplied() throws {
                 let logger = TestLogger()
                 let internalQueue = TestFactories.createInternalQueue()
-                let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+                let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
                 let map = InternalDefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstonedAt: nil, timeserial: "ts1", data: ObjectData(string: "existing"))],
@@ -866,7 +866,7 @@ struct InternalDefaultLiveMapTests {
         func mapOperationApplicability(entrySerial: String?, operationSerial: String?, shouldApply: Bool) throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(
                 testsOnly_data: ["key1": TestFactories.internalMapEntry(timeserial: entrySerial, data: ObjectData(string: "existing"))],
@@ -904,7 +904,7 @@ struct InternalDefaultLiveMapTests {
         func appliesMapSetOperationsFromOperation() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             var pool = ObjectsPool(logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
@@ -930,7 +930,7 @@ struct InternalDefaultLiveMapTests {
         func appliesMapRemoveOperationsFromOperation() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap(
                 testsOnly_data: ["key1": TestFactories.internalStringMapEntry().entry],
@@ -1031,7 +1031,7 @@ struct InternalDefaultLiveMapTests {
         func discardsOperationWhenCreateOperationIsMerged() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             var pool = ObjectsPool(logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
@@ -1064,7 +1064,7 @@ struct InternalDefaultLiveMapTests {
         func mergesInitialValue() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             var pool = ObjectsPool(logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
@@ -1096,7 +1096,7 @@ struct InternalDefaultLiveMapTests {
         func discardsOperationWhenCannotBeApplied() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 
@@ -1145,7 +1145,7 @@ struct InternalDefaultLiveMapTests {
         func appliesMapCreateOperation() async throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 
@@ -1187,7 +1187,7 @@ struct InternalDefaultLiveMapTests {
         func appliesMapSetOperation() async throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 
@@ -1243,7 +1243,7 @@ struct InternalDefaultLiveMapTests {
         func appliesMapRemoveOperation() async throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
 

--- a/Tests/AblyLiveObjectsTests/Mocks/MockLiveMapObjectsPoolDelegate.swift
+++ b/Tests/AblyLiveObjectsTests/Mocks/MockLiveMapObjectsPoolDelegate.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 /// A mock delegate that can return predefined objects
-final class MockLiveMapObjectPoolDelegate: LiveMapObjectPoolDelegate {
+final class MockLiveMapObjectsPoolDelegate: LiveMapObjectsPoolDelegate {
     private let poolMutex: DispatchQueueMutex<ObjectsPool>
 
     init(internalQueue: DispatchQueue) {

--- a/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
@@ -89,7 +89,7 @@ struct ObjectsPoolTests {
         func updatesExistingMapObject() async throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
             let existingMap = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
             let existingMapSubscriber = Subscriber<DefaultLiveMapUpdate, SubscribeResponse>(callbackQueue: .main)
@@ -194,7 +194,7 @@ struct ObjectsPoolTests {
         func createsNewMapObject() throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
 
             var pool = ObjectsPool(logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
@@ -301,7 +301,7 @@ struct ObjectsPoolTests {
         func handlesComplexSyncScenario() async throws {
             let logger = TestLogger()
             let internalQueue = TestFactories.createInternalQueue()
-            let delegate = MockLiveMapObjectPoolDelegate(internalQueue: internalQueue)
+            let delegate = MockLiveMapObjectsPoolDelegate(internalQueue: internalQueue)
             let coreSDK = MockCoreSDK(channelState: .attaching, internalQueue: internalQueue)
 
             let existingMap = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())


### PR DESCRIPTION
**Note: This PR is based on top of #87; please review that one first.**

It's nicer to deal with value types instead of objects (the latter coming with synchronisation requirements to worry about).

Resolves #39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Switched internal map access to a snapshot-based pool interface for more consistent, local pool reads and improved performance.
  - Renamed internal delegate types for clarity; no changes to public APIs or user-facing behavior.

- Tests
  - Replaced and strengthened test mocks to align with the new pool interface, improving thread-safety and test reliability.

- Chores
  - Minor comment and documentation updates to reflect naming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->