### PR TITLE
Update dependencies for 0.2.0

### DIFF
--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "db81b5b63dd3c181dd6b5858443bec813293f75bfb7d44371053c1cc7bf30d70",
+  "originHash" : "a9bb12b2370d8ccfa25000a37b1301668b79689668f71059fea14431be9a0649",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "6bcbf5faaa7b577f4fe8129d895be0f24258aa27"
+        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
+        "version" : "1.2.46"
       }
     },
     {
@@ -14,7 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "2ce1058ed4430cc3563dcead0299e92a81d2774b"
+        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "1e8978bd03f19fa4f0f7ec194d9281e28f2f5c2292ac744452a40ae531b4fb56",
+  "originHash" : "6b347363915d5bce46289bd7c3815b40c1d86d54160d10dced8b6a07956652e3",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "6bcbf5faaa7b577f4fe8129d895be0f24258aa27"
+        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
+        "version" : "1.2.46"
       }
     },
     {
@@ -14,7 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "2ce1058ed4430cc3563dcead0299e92a81d2774b"
+        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",
-            from: "0.2.0",
+            // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0.
+            exact: "0.2.0",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            // TODO: Unpin before next release
-            revision: "6bcbf5faaa7b577f4fe8129d895be0f24258aa27",
+            from: "1.2.46",
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",
-            // TODO: Unpin before next release
-            revision: "2ce1058ed4430cc3563dcead0299e92a81d2774b",
+            from: "0.2.0",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",


### PR DESCRIPTION
This includes using `exact:` instead of `from:` for ably-cocoa-liveobjects-plugin, to avoid SPM automatically resolving to future versions of ably-cocoa-plugin-support (which was causing users compilation errors on LiveObjects 0.1.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated realtime SDK dependencies to released versions: ably-cocoa 1.2.46 and ably-cocoa-plugin-support 0.2.0.
  - Builds now reference semantic versions instead of commit revisions for these packages, providing more predictable updates across environments.
  - No user-facing functionality or UI changes are included in this release.
  - All other dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->